### PR TITLE
removing self from maintainers

### DIFF
--- a/terraform.tfvars.json
+++ b/terraform.tfvars.json
@@ -15,7 +15,6 @@
         "fernandoaleman",
         "nuclearsandwich",
         "mohitsethi",
-        "majormoses",
         "teknofire",
         "rshade",
         "mengesb",


### PR DESCRIPTION
I am no longer working for a company using chef and I have drifted from the ecosystem over the years. Maybe one day we will cross paths again, either way it was a blast. As we have a healthy group of active maintainers, I gladly give up my access that I no longer need.